### PR TITLE
docs: add meta-repository markdown cleanup guide

### DIFF
--- a/docs/META_REPO_CLEANUP.md
+++ b/docs/META_REPO_CLEANUP.md
@@ -28,12 +28,10 @@ These files were **not version controlled** and needed evaluation for relevance 
 - **Rationale**: The larger documentation file contains all relevant information plus additional details
 
 #### LOCAL_CI_SETUP.md
-- **Status**: PARTIALLY USEFUL - Contains unique information about `act` tool for running GitHub Actions locally
-- **Decision**: KEEP temporarily, content should be:
-  1. Integrated into a versioned documentation repo (if `act` is still actively used)
-  2. Deleted if `act` is no longer part of the development workflow
-- **Recommendation**: Ask project maintainer if `act` tool documentation is still needed
-- **Unique Content**:
+- **Status**: OBSOLETE - Contains documentation for `act` tool which is no longer used
+- **Decision**: DELETE
+- **Rationale**: The `act` tool for running GitHub Actions locally is no longer part of the development workflow. The project now uses self-hosted GitHub Actions runners in Docker containers instead.
+- **Historical Content**:
   - How to install and use `act` tool
   - `.actrc` configuration files
   - Platform mapping for self-hosted runners
@@ -47,11 +45,10 @@ These files were **not version controlled** and needed evaluation for relevance 
 - [x] Create this cleanup guide
 
 ### Recommended Actions
-- [ ] Confirm with maintainer if `act` tool is still used
-- [ ] If YES: Integrate LOCAL_CI_SETUP.md content into versioned docs
-- [ ] If NO: Delete LOCAL_CI_SETUP.md
-- [ ] Delete CICD_SETUP.md (confirmed redundant)
-- [ ] Keep CONTRIBUTING.md and CLAUDE.md at root
+- [x] Confirm with maintainer if `act` tool is still used (CONFIRMED: No longer used)
+- [x] Delete LOCAL_CI_SETUP.md (obsolete - act tool no longer used)
+- [x] Delete CICD_SETUP.md (confirmed redundant)
+- [x] Keep CONTRIBUTING.md and CLAUDE.md at root
 
 ## Notes
 

--- a/docs/META_REPO_CLEANUP.md
+++ b/docs/META_REPO_CLEANUP.md
@@ -1,0 +1,67 @@
+# Meta-Repository Documentation Cleanup
+
+## Overview
+
+This document explains the cleanup of markdown documentation files at the root of the TheOpenMusicBox meta-repository.
+
+## Problem Statement
+
+Several markdown files existed at the root of the local meta-repository (`/Users/jonathanpiette/github/theopenmusicbox/`):
+- `CICD_SETUP.md` (7.6KB)
+- `LOCAL_CI_SETUP.md` (4KB)
+- `CONTRIBUTING.md` (12KB)
+- `CLAUDE.md` (814 bytes)
+
+These files were **not version controlled** and needed evaluation for relevance and proper organization.
+
+## Analysis & Decisions
+
+### Files to Keep (at meta-repo root)
+- **CONTRIBUTING.md** - Standard GitHub contribution guidelines, should remain at project root for visibility
+- **CLAUDE.md** - Workflow instructions for Claude Code tool, convention is to keep at root
+
+### Files to Remove (obsolete/redundant)
+
+#### CICD_SETUP.md
+- **Status**: REDUNDANT - Content is covered more comprehensively in `docs/CICD_DOCUMENTATION.md` (945 lines vs 284 lines)
+- **Decision**: DELETE
+- **Rationale**: The larger documentation file contains all relevant information plus additional details
+
+#### LOCAL_CI_SETUP.md
+- **Status**: PARTIALLY USEFUL - Contains unique information about `act` tool for running GitHub Actions locally
+- **Decision**: KEEP temporarily, content should be:
+  1. Integrated into a versioned documentation repo (if `act` is still actively used)
+  2. Deleted if `act` is no longer part of the development workflow
+- **Recommendation**: Ask project maintainer if `act` tool documentation is still needed
+- **Unique Content**:
+  - How to install and use `act` tool
+  - `.actrc` configuration files
+  - Platform mapping for self-hosted runners
+  - Troubleshooting act-specific issues
+
+## Action Items
+
+### Completed
+- [x] Evaluate each markdown file at meta-repo root
+- [x] Compare with existing documentation in `docs/`
+- [x] Create this cleanup guide
+
+### Recommended Actions
+- [ ] Confirm with maintainer if `act` tool is still used
+- [ ] If YES: Integrate LOCAL_CI_SETUP.md content into versioned docs
+- [ ] If NO: Delete LOCAL_CI_SETUP.md
+- [ ] Delete CICD_SETUP.md (confirmed redundant)
+- [ ] Keep CONTRIBUTING.md and CLAUDE.md at root
+
+## Notes
+
+The meta-repository at `/Users/jonathanpiette/github/theopenmusicbox/` is not a Git repository itself - it's a collection of submodules. Documentation files at its root are **local only** and not version controlled.
+
+For project-wide documentation that should be version controlled, consider:
+1. Using this `.github` repository (organization-wide docs)
+2. Creating a dedicated `docs` repository
+3. Adding documentation to the most relevant component repository
+
+## Related Issues
+
+- Issue #3: docs: cleanup markdown files at meta-repository root

--- a/docs/cleanup_meta_repo.sh
+++ b/docs/cleanup_meta_repo.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# cleanup_meta_repo.sh - Clean up redundant markdown files in meta-repository
+#
+# This script removes redundant markdown documentation files from the
+# TheOpenMusicBox meta-repository root.
+
+set -euo pipefail
+
+# Define colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Meta-repo root (adjust if needed)
+META_REPO_ROOT="/Users/jonathanpiette/github/theopenmusicbox"
+
+echo "========================================="
+echo "Meta-Repository Markdown Cleanup Script"
+echo "========================================="
+echo ""
+
+# Check if we're in the right location
+if [ ! -d "$META_REPO_ROOT" ]; then
+    echo -e "${RED}Error: Meta-repository not found at $META_REPO_ROOT${NC}"
+    exit 1
+fi
+
+cd "$META_REPO_ROOT"
+echo "Working directory: $(pwd)"
+echo ""
+
+# Function to remove a file with confirmation
+remove_file() {
+    local file="$1"
+    local reason="$2"
+
+    if [ ! -f "$file" ]; then
+        echo -e "${YELLOW}⚠ File not found: $file (already removed?)${NC}"
+        return 0
+    fi
+
+    echo -e "${YELLOW}File: $file${NC}"
+    echo "Reason: $reason"
+    echo "Size: $(wc -l < "$file") lines"
+    echo ""
+
+    read -p "Remove this file? (y/N) " -n 1 -r
+    echo ""
+    if [[ $REPLY =~ ^[Yy]$ ]]; then
+        rm "$file"
+        echo -e "${GREEN}✓ Removed: $file${NC}"
+    else
+        echo -e "${YELLOW}✗ Skipped: $file${NC}"
+    fi
+    echo ""
+}
+
+# Function to keep a file
+keep_file() {
+    local file="$1"
+    local reason="$2"
+
+    if [ ! -f "$file" ]; then
+        echo -e "${RED}⚠ File not found: $file (missing?)${NC}"
+        return 1
+    fi
+
+    echo -e "${GREEN}✓ Keeping: $file${NC}"
+    echo "  Reason: $reason"
+    echo ""
+}
+
+echo "=== Files to KEEP ==="
+echo ""
+keep_file "CONTRIBUTING.md" "Standard GitHub contribution guidelines"
+keep_file "CLAUDE.md" "Claude Code workflow instructions"
+
+echo ""
+echo "=== Files to REMOVE ==="
+echo ""
+
+remove_file "CICD_SETUP.md" "Redundant - content covered in docs/CICD_DOCUMENTATION.md"
+
+echo ""
+echo "=== Files to REVIEW ==="
+echo ""
+
+if [ -f "LOCAL_CI_SETUP.md" ]; then
+    echo -e "${YELLOW}File: LOCAL_CI_SETUP.md${NC}"
+    echo "Contains information about 'act' tool for local CI testing"
+    echo "Question: Is the 'act' tool still actively used in your workflow?"
+    echo ""
+    echo "Options:"
+    echo "  1) Keep - if act is still used"
+    echo "  2) Remove - if act is no longer used"
+    echo "  3) Skip - decide later"
+    echo ""
+    read -p "Enter choice (1/2/3): " -n 1 -r
+    echo ""
+
+    case $REPLY in
+        1)
+            echo -e "${GREEN}✓ Keeping: LOCAL_CI_SETUP.md${NC}"
+            echo "  Consider moving this to version-controlled docs later"
+            ;;
+        2)
+            rm "LOCAL_CI_SETUP.md"
+            echo -e "${GREEN}✓ Removed: LOCAL_CI_SETUP.md${NC}"
+            ;;
+        3)
+            echo -e "${YELLOW}✗ Skipped: LOCAL_CI_SETUP.md${NC}"
+            ;;
+        *)
+            echo -e "${YELLOW}✗ Invalid choice, skipped${NC}"
+            ;;
+    esac
+    echo ""
+fi
+
+echo "========================================="
+echo "Cleanup complete!"
+echo "========================================="
+echo ""
+echo "Remaining markdown files at root:"
+ls -lh *.md 2>/dev/null || echo "  (none found)"
+echo ""
+echo "For more information, see:"
+echo "  https://github.com/The-Open-Music-Box/.github/blob/docs/issue-3-md-cleanup/docs/META_REPO_CLEANUP.md"

--- a/docs/cleanup_meta_repo.sh
+++ b/docs/cleanup_meta_repo.sh
@@ -82,41 +82,7 @@ echo ""
 
 remove_file "CICD_SETUP.md" "Redundant - content covered in docs/CICD_DOCUMENTATION.md"
 
-echo ""
-echo "=== Files to REVIEW ==="
-echo ""
-
-if [ -f "LOCAL_CI_SETUP.md" ]; then
-    echo -e "${YELLOW}File: LOCAL_CI_SETUP.md${NC}"
-    echo "Contains information about 'act' tool for local CI testing"
-    echo "Question: Is the 'act' tool still actively used in your workflow?"
-    echo ""
-    echo "Options:"
-    echo "  1) Keep - if act is still used"
-    echo "  2) Remove - if act is no longer used"
-    echo "  3) Skip - decide later"
-    echo ""
-    read -p "Enter choice (1/2/3): " -n 1 -r
-    echo ""
-
-    case $REPLY in
-        1)
-            echo -e "${GREEN}✓ Keeping: LOCAL_CI_SETUP.md${NC}"
-            echo "  Consider moving this to version-controlled docs later"
-            ;;
-        2)
-            rm "LOCAL_CI_SETUP.md"
-            echo -e "${GREEN}✓ Removed: LOCAL_CI_SETUP.md${NC}"
-            ;;
-        3)
-            echo -e "${YELLOW}✗ Skipped: LOCAL_CI_SETUP.md${NC}"
-            ;;
-        *)
-            echo -e "${YELLOW}✗ Invalid choice, skipped${NC}"
-            ;;
-    esac
-    echo ""
-fi
+remove_file "LOCAL_CI_SETUP.md" "Obsolete - act tool no longer used in workflow"
 
 echo "========================================="
 echo "Cleanup complete!"


### PR DESCRIPTION
## Summary

Adds documentation and tooling to guide the cleanup of redundant markdown files in the TheOpenMusicBox meta-repository.

## Changes

### Documentation
- **META_REPO_CLEANUP.md**: Comprehensive analysis of markdown files at meta-repo root
  - Evaluation of each file (CICD_SETUP.md, LOCAL_CI_SETUP.md, CONTRIBUTING.md, CLAUDE.md)
  - Recommendations for keeping, removing, or reviewing each file
  - Rationale for each decision

### Automation
- **cleanup_meta_repo.sh**: Interactive shell script for safe cleanup
  - Automated removal of confirmed redundant files
  - Interactive prompts for files requiring manual decision
  - Safety confirmations before deletion
  - Color-coded output for clarity

## Findings

### Files to Keep
- **CONTRIBUTING.md** - Standard location for GitHub contribution guidelines
- **CLAUDE.md** - Workflow instructions for Claude Code tool

### Files to Remove
- **CICD_SETUP.md** - Redundant (content covered in `docs/CICD_DOCUMENTATION.md` which is 3x more comprehensive)

### Files to Review
- **LOCAL_CI_SETUP.md** - Contains unique information about `act` tool
  - Decision depends on whether `act` tool is still actively used
  - If YES: Content should be integrated into version-controlled docs
  - If NO: File should be deleted

## Usage

To execute the cleanup:

bash
cd /Users/jonathanpiette/github/theopenmusicbox
./cleanup_meta_repo.sh